### PR TITLE
INTERLOK-3555 Update the pom url to point to the right doc page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,7 +215,7 @@ publishing {
       pom.withXml {
         asNode().appendNode("name", componentName)
         asNode().appendNode("description", "Embedded Apache Artemis management component")
-        asNode().appendNode("url", "http://interlok.adaptris.net/interlok-docs/adapter-bootstrap.html#apache-artemis")
+        asNode().appendNode("url", "https://interlok.adaptris.net/interlok-docs/#/pages/user-guide/adapter-bootstrap?id=apache-artemis")
         def properties = asNode().appendNode("properties")
         properties.appendNode("target", "3.9.0+")
         properties.appendNode("license", "false")


### PR DESCRIPTION
## Motivation

The documentation was broken since we changed the doc site

## Modification

Fix the doc url

## Result

The pom has a correct doc url

## Testing

Check that the new url exists in the POM file after running gradle generatePomFileForMavenJavaPublication.
